### PR TITLE
style(nodejs): remove unnecessary `async` keyword

### DIFF
--- a/src/sender.js
+++ b/src/sender.js
@@ -89,7 +89,7 @@ class Sender {
      * @param {net.NetConnectOpts | tls.ConnectionOptions} options - Connection options, host and port are required.
      * @param {boolean} [secure = false] - If true connection will use TLS encryption.
      */
-    async connect(options, secure = false) {
+    connect(options, secure = false) {
         let self = this;
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
The `connect` method already returns a promise, the `async` keyword is
not required.

This is a cosmetic change only.