### PR TITLE
use `localhost` instead of `127.0.0.1` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ async function run() {
 
     // connect to QuestDB
     // host and port are required in connect options
-    await sender.connect({port: 9009, host: "127.0.0.1"});
+    await sender.connect({port: 9009, host: "localhost"});
 
     // add rows to the buffer of the sender
     sender.table("prices").symbol("instrument", "EURUSD")
@@ -69,7 +69,7 @@ async function run() {
 
     // connect() takes an optional second argument
     // if 'true' passed the connection is secured with TLS encryption
-    await sender.connect({port: 9009, host: "127.0.0.1"}, true);
+    await sender.connect({port: 9009, host: "localhost"}, true);
 
     // send the data over the authenticated and secure connection
     sender.table("prices").symbol("instrument", "EURUSD")
@@ -110,7 +110,7 @@ async function run(): Promise<number> {
 
     // connect() takes an optional second argument
     // if 'true' passed the connection is secured with TLS encryption
-    await sender.connect({port: 9009, host: "127.0.0.1"}, true);
+    await sender.connect({port: 9009, host: "localhost"}, true);
 
     // send the data over the authenticated and secure connection
     sender.table("prices").symbol("instrument", "EURUSD")

--- a/examples/auth.js
+++ b/examples/auth.js
@@ -22,7 +22,7 @@ async function run() {
 
   // connect() takes an optional second argument
   // if 'true' passed the connection is secured with TLS encryption
-  await sender.connect({ port: 9009, host: "127.0.0.1" }, false);
+  await sender.connect({ port: 9009, host: "localhost" }, false);
 
   // send the data over the authenticated connection
   sender

--- a/examples/auth.js
+++ b/examples/auth.js
@@ -6,7 +6,7 @@ async function run() {
   const PRIVATE_KEY = "9b9x5WhJywDEuo1KGQWSPNxtX-6X6R2BRCKhYMMY6n8";
   const PUBLIC_KEY = {
     x: "aultdA0PjhD_cWViqKKyL5chm6H1n-BiZBo_48T-uqc",
-    y: "__ptaol41JWSpTTL525yVEfzmY8A6Vi_QrW1FjKcHMg"
+    y: "__ptaol41JWSpTTL525yVEfzmY8A6Vi_QrW1FjKcHMg",
   };
   const JWK = {
     ...PUBLIC_KEY,
@@ -18,15 +18,19 @@ async function run() {
 
   // pass the JsonWebKey to the sender
   // will use it for authentication
-  const sender = new Sender({bufferSize: 4096, jwk: JWK});
+  const sender = new Sender({ bufferSize: 4096, jwk: JWK });
 
   // connect() takes an optional second argument
   // if 'true' passed the connection is secured with TLS encryption
-  await sender.connect({port: 9009, host: "127.0.0.1"}, false);
+  await sender.connect({ port: 9009, host: "127.0.0.1" }, false);
 
   // send the data over the authenticated connection
-  sender.table("prices").symbol("instrument", "EURUSD")
-      .floatColumn("bid", 1.0197).floatColumn("ask", 1.0224).atNow();
+  sender
+    .table("prices")
+    .symbol("instrument", "EURUSD")
+    .floatColumn("bid", 1.0197)
+    .floatColumn("ask", 1.0224)
+    .atNow();
   await sender.flush();
 
   // close the connection after all rows ingested
@@ -34,4 +38,7 @@ async function run() {
   return 0;
 }
 
-run().then(value => console.log(value)).catch(err => console.log(err));
+run()
+  .then((value) => console.log(value))
+  .catch((err) => console.log(err));
+

--- a/examples/auth_tls.js
+++ b/examples/auth_tls.js
@@ -22,7 +22,7 @@ async function run() {
 
   // connect() takes an optional second argument
   // if 'true' passed the connection is secured with TLS encryption
-  await sender.connect({ port: 9009, host: "127.0.0.1" }, true);
+  await sender.connect({ port: 9009, host: "localhost" }, true);
 
   // send the data over the authenticated and secure connection
   sender

--- a/examples/auth_tls.js
+++ b/examples/auth_tls.js
@@ -6,7 +6,7 @@ async function run() {
   const PRIVATE_KEY = "9b9x5WhJywDEuo1KGQWSPNxtX-6X6R2BRCKhYMMY6n8";
   const PUBLIC_KEY = {
     x: "aultdA0PjhD_cWViqKKyL5chm6H1n-BiZBo_48T-uqc",
-    y: "__ptaol41JWSpTTL525yVEfzmY8A6Vi_QrW1FjKcHMg"
+    y: "__ptaol41JWSpTTL525yVEfzmY8A6Vi_QrW1FjKcHMg",
   };
   const JWK = {
     ...PUBLIC_KEY,
@@ -18,15 +18,20 @@ async function run() {
 
   // pass the JsonWebKey to the sender
   // will use it for authentication
-  const sender = new Sender({bufferSize: 4096, jwk: JWK});
+  const sender = new Sender({ bufferSize: 4096, jwk: JWK });
 
   // connect() takes an optional second argument
   // if 'true' passed the connection is secured with TLS encryption
-  await sender.connect({port: 9009, host: "127.0.0.1"}, true);
+  await sender.connect({ port: 9009, host: "127.0.0.1" }, true);
 
   // send the data over the authenticated and secure connection
-  sender.table("prices").symbol("instrument", "EURUSD")
-      .floatColumn("bid", 1.0197).floatColumn("ask", 1.0224).atNow();
+  sender
+    .table("prices")
+    .symbol("instrument", "EURUSD")
+    .floatColumn("bid", 1.0197)
+    .floatColumn("ask", 1.0224)
+    .atNow();
+
   await sender.flush();
 
   // close the connection after all rows ingested
@@ -34,4 +39,6 @@ async function run() {
   return 0;
 }
 
-run().then(value => console.log(value)).catch(err => console.log(err));
+run()
+  .then((value) => console.log(value))
+  .catch((err) => console.log(err));

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -6,7 +6,7 @@ async function run() {
 
   // connect to QuestDB
   // host and port are required in connect options
-  await sender.connect({ port: 9009, host: "127.0.0.1" });
+  await sender.connect({ port: 9009, host: "localhost" });
 
   // add rows to the buffer of the sender
   sender

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -2,25 +2,39 @@ const { Sender } = require("@questdb/nodejs-client");
 
 async function run() {
   // create a sender with a 4k buffer
-  const sender = new Sender({bufferSize: 4096});
+  const sender = new Sender({ bufferSize: 4096 });
 
   // connect to QuestDB
   // host and port are required in connect options
-  await sender.connect({port: 9009, host: "127.0.0.1"});
+  await sender.connect({ port: 9009, host: "127.0.0.1" });
 
   // add rows to the buffer of the sender
-  sender.table("prices").symbol("instrument", "EURUSD")
-      .floatColumn("bid", 1.0195).floatColumn("ask", 1.0221).atNow();
-  sender.table("prices").symbol("instrument", "GBPUSD")
-      .floatColumn("bid", 1.2076).floatColumn("ask", 1.2082).atNow();
+  sender
+    .table("prices")
+    .symbol("instrument", "EURUSD")
+    .floatColumn("bid", 1.0195)
+    .floatColumn("ask", 1.0221)
+    .atNow();
+
+  sender
+    .table("prices")
+    .symbol("instrument", "GBPUSD")
+    .floatColumn("bid", 1.2076)
+    .floatColumn("ask", 1.2082)
+    .atNow();
 
   // flush the buffer of the sender, sending the data to QuestDB
   // the buffer is cleared after the data is sent and the sender is ready to accept new data
   await sender.flush();
 
   // add rows to the buffer again and send it to the server
-  sender.table("prices").symbol("instrument", "EURUSD")
-      .floatColumn("bid", 1.0197).floatColumn("ask", 1.0224).atNow();
+  sender
+    .table("prices")
+    .symbol("instrument", "EURUSD")
+    .floatColumn("bid", 1.0197)
+    .floatColumn("ask", 1.0224)
+    .atNow();
+
   await sender.flush();
 
   // close the connection after all rows ingested
@@ -28,4 +42,6 @@ async function run() {
   return 0;
 }
 
-run().then(value => console.log(value)).catch(err => console.log(err));
+run()
+  .then((value) => console.log(value))
+  .catch((err) => console.log(err));


### PR DESCRIPTION
in This PR:
- format example code with prettier
- use `localhost` instead of `127.0.0.1` in examples

The example code is used in other code bases to showcase how this client
should be used.

It is also used with [`examples.manifest.yaml`](https://github.com/questdb/nodejs-questdb-client/blob/fix-host-in-examples/examples.manifest.yaml), which describes examples with interpolatable values.

In particular, the [`examples.manifest.yaml`](https://github.com/questdb/nodejs-questdb-client/blob/fix-host-in-examples/examples.manifest.yaml) has these:

```
  addr:
    host: localhost
    port: 9009
```

when example code like [`./examples/basic.js`](https://github.com/questdb/nodejs-questdb-client/blob/fix-host-in-examples/examples/basic.js) is interpolated with values from `examples.manifest.yaml`, the `host` part is missed.

Thus, we should be consistent and in both `examples.manifest.yaml` and `examples/*.js` use as `host` either:

1. `localhost` or
2. `127.0.0.1`

This PR chooses `localhost`
