### PR TITLE
chore(nodejs): test against the nightly QuestDB docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
   schedule:
-    - cron: '15 2 * * *'
+    - cron: '15 2,10,18 * * *'
 
 jobs:
   test:

--- a/test/sender.test.js
+++ b/test/sender.test.js
@@ -1469,7 +1469,7 @@ describe('Sender tests with containerized QuestDB instance', () => {
 
     beforeAll(async () => {
         jest.setTimeout(3000000);
-        container = await new GenericContainer('questdb/questdb:7.4.0')
+        container = await new GenericContainer('questdb/questdb:nightly')
             .withExposedPorts(QUESTDB_HTTP_PORT, QUESTDB_ILP_PORT)
             .start();
 


### PR DESCRIPTION
- test against the nightly QuestDB docker image instead of a fixed version
- increase the frequency of nightly builds, it will run 3 times a day