### PR TITLE
chore(nodejs): refactor buffer handling

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -105,11 +105,6 @@ const UNSAFE_OFF = "unsafe_off";
  * <li> max_name_len: <i>integer</i> - The maximum length of a table or column name, the Sender defaults this parameter to 127. <br>
  * Recommended to use the same setting as the server, which also uses 127 by default.
  * </li>
- * <li> copy_buffer: <i>enum, accepted values: on, off</i> - By default, the Sender creates a new buffer for every flush() call,
- * and the data to be sent to the server is copied into this new buffer.
- * Setting the flag to <i>off</i> results in reusing the same buffer instance for each flush() call. <br>
- * Use this flag only if calls to the client are serialised.
- * </li>
  * </ul>
  */
 class SenderOptions {
@@ -128,9 +123,6 @@ class SenderOptions {
   auto_flush?: boolean;
   auto_flush_rows?: number;
   auto_flush_interval?: number;
-
-  // replaces `copyBuffer` option
-  copy_buffer?: string | boolean | null;
 
   request_min_throughput?: number;
   request_timeout?: number;
@@ -243,7 +235,6 @@ function parseConfigurationString(
   parseTlsOptions(options);
   parseRequestTimeoutOptions(options);
   parseMaxNameLength(options);
-  parseCopyBuffer(options);
 }
 
 function parseSettings(
@@ -299,7 +290,6 @@ const ValidConfigKeys = [
   "auto_flush",
   "auto_flush_rows",
   "auto_flush_interval",
-  "copy_buffer",
   "request_min_throughput",
   "request_timeout",
   "retry_timeout",
@@ -430,10 +420,6 @@ function parseRequestTimeoutOptions(options: SenderOptions) {
 
 function parseMaxNameLength(options: SenderOptions) {
   parseInteger(options, "max_name_len", "max name length", 1);
-}
-
-function parseCopyBuffer(options: SenderOptions) {
-  parseBoolean(options, "copy_buffer", "copy buffer");
 }
 
 function parseBoolean(

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -627,41 +627,6 @@ describe("Configuration string parser suite", function () {
     ).toThrow("Invalid retry timeout option, not a number: '6w0'");
   });
 
-  it("can parse copy_buffer config", function () {
-    let options = SenderOptions.fromConfig(
-      "http::addr=host:9000;copy_buffer=on;",
-    );
-    expect(options.protocol).toBe("http");
-    expect(options.host).toBe("host");
-    expect(options.port).toBe(9000);
-    expect(options.copy_buffer).toBe(true);
-
-    options = SenderOptions.fromConfig("http::addr=host:9000;copy_buffer=off;");
-    expect(options.protocol).toBe("http");
-    expect(options.host).toBe("host");
-    expect(options.port).toBe(9000);
-    expect(options.copy_buffer).toBe(false);
-
-    expect(() =>
-      SenderOptions.fromConfig("http::addr=host:9000;copy_buffer=ON;"),
-    ).toThrow("Invalid copy buffer option: 'ON'");
-    expect(() =>
-      SenderOptions.fromConfig("http::addr=host:9000;copy_buffer=On;"),
-    ).toThrow("Invalid copy buffer option: 'On'");
-    expect(() =>
-      SenderOptions.fromConfig("http::addr=host:9000;copy_buffer=true;"),
-    ).toThrow("Invalid copy buffer option: 'true'");
-    expect(() =>
-      SenderOptions.fromConfig("http::addr=host:9000;copy_buffer=OFF;"),
-    ).toThrow("Invalid copy buffer option: 'OFF'");
-    expect(() =>
-      SenderOptions.fromConfig("http::addr=host:9000;copy_buffer=Off;"),
-    ).toThrow("Invalid copy buffer option: 'Off'");
-    expect(() =>
-      SenderOptions.fromConfig("http::addr=host:9000;copy_buffer=false;"),
-    ).toThrow("Invalid copy buffer option: 'false'");
-  });
-
   it("can parse max_name_len config", function () {
     const options = SenderOptions.fromConfig(
       "http::addr=host:9000;max_name_len=30",


### PR DESCRIPTION
Refactor buffer handling to look more like it was before PR https://github.com/questdb/nodejs-questdb-client/pull/42

- when flush() is called, the buffer gets compacted right after a copy is made for sending
- deprecating the `copy_buffer` option, we always create a copy of the sender's buffer for sending, even if calls to the sender are fully sequential
- since all async sending tasks are working on their own buffer, we can remove promise chaining