### PR TITLE
chore(nodejs): expose SenderOptions class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@
  */
 
 export { Sender } from "./sender";
-export type { SenderOptions, ExtraOptions } from "./options";
+export { SenderOptions } from "./options";
+export type { ExtraOptions } from "./options";
 export type { TimestampUnit } from "./utils";
 export type { SenderBuffer } from "./buffer";
 export { SenderBufferV1 } from "./buffer/bufferv1";


### PR DESCRIPTION
Expose the `SenderOptions` class for consumers to be able to build options from a configuration string. Useful for using `SenderBuffer` and `SenderTransport` without going through the `Sender`.

Context:

We would like to use the `SenderTransport`, `SenderBuffer` and `SenderOptions` classes for a custom `Sender` that caches the buffer contents. However, `SenderOptions` is only exposed as a type and therefore we cannot use `SenderOptions.fromConfig` and other methods.